### PR TITLE
Wrapped createPluginFilter function call in a macro

### DIFF
--- a/Decoder/Source/PluginProcessor.cpp
+++ b/Decoder/Source/PluginProcessor.cpp
@@ -589,7 +589,11 @@ void AmbisonicsDecoderAudioProcessor::numChannelsChanged()
 
 //==============================================================================
 // This creates new instances of the plugin..
+#if !(JUCE_DONT_EMIT_CREATE_PLUGIN_FILTER)
+
 AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
     return new AmbisonicsDecoderAudioProcessor();
 }
+
+#endif

--- a/Encoder/Source/PluginProcessor.cpp
+++ b/Encoder/Source/PluginProcessor.cpp
@@ -503,7 +503,12 @@ void AmbisonicEncoderAudioProcessor::actionListenerCallback(const juce::String &
 
 //==============================================================================
 // This creates new instances of the plugin..
+#if !(JUCE_DONT_EMIT_CREATE_PLUGIN_FILTER)
+
 AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
     return new AmbisonicEncoderAudioProcessor();
 }
+
+#endif
+


### PR DESCRIPTION
Defining the macro JUCE_DONT_EMIT_CREATE_PLUGIN_FILTER as 1 will remove the createPluginFilter() function definition from compilation so source files can be included in other plugins